### PR TITLE
Portugese: change file encoding to UTF-8

### DIFF
--- a/src/lang_pt.c
+++ b/src/lang_pt.c
@@ -3,7 +3,7 @@
 /* Based on BIP-39 (unchanged) */
 
 POLYSEED_PRIVATE const polyseed_lang polyseed_lang_pt = {
-    .name = u8"português",
+    .name = u8"portuguÃªs",
     .name_en = "Portuguese",
     .separator = " ",
     .is_sorted = true,


### PR DESCRIPTION
Xcode does not like ISO-8859-1. https://stackoverflow.com/a/14736014

Fixes the following issue when compiling on macOS.

```
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting default build type: Release
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/runner/work/feather/feather/polyseed
[  2%] Building C object CMakeFiles/polyseed.dir/src/dependency.c.o
[  5%] Building C object CMakeFiles/polyseed.dir/src/features.c.o
[  8%] Building C object CMakeFiles/polyseed.dir/src/gf.c.o
[ 11%] Building C object CMakeFiles/polyseed.dir/src/lang.c.o
[ 13%] Building C object CMakeFiles/polyseed.dir/src/lang_cs.c.o
[ 16%] Building C object CMakeFiles/polyseed.dir/src/lang_en.c.o
[ 19%] Building C object CMakeFiles/polyseed.dir/src/lang_es.c.o
[ 22%] Building C object CMakeFiles/polyseed.dir/src/lang_fr.c.o
[ 25%] Building C object CMakeFiles/polyseed.dir/src/lang_it.c.o
[ 27%] Building C object CMakeFiles/polyseed.dir/src/lang_jp.c.o
[ 30%] Building C object CMakeFiles/polyseed.dir/src/lang_ko.c.o
[ 33%] Building C object CMakeFiles/polyseed.dir/src/lang_pt.c.o
/Users/runner/work/feather/feather/polyseed/src/lang_pt.c:6:23: error: illegal character encoding in string literal
    .name = u8"portugu<EA>s",
                      ^~~~
1 error generated.
```

Converted using: `iconv -f iso-8859-1 -t utf-8 lang_pt.c`

Before:

```
$ file -b --mime-encoding lang_pt.c
iso-8859-1
```

After:

```
$ file -b --mime-encoding lang_pt.c
utf-8
```
