### PR TITLE
compose japanese language

### DIFF
--- a/src/lang_jp.c
+++ b/src/lang_jp.c
@@ -9,7 +9,7 @@ POLYSEED_PRIVATE const polyseed_lang polyseed_lang_jp = {
     .is_sorted = true,
     .has_prefix = false,
     .has_accents = false,
-    .compose = false,
+    .compose = true,
     .words = {
         u8"あいこくしん",
         u8"あいさつ",


### PR DESCRIPTION
E.g.:
`ひさしふ ゙ り` should be displayed as: `ひさしぶり`