### PR TITLE
Handle seeds that can decode in multiple languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set_property(TARGET polyseed PROPERTY PUBLIC_HEADER include/polyseed.h)
 include_directories(polyseed
   include/)
 target_compile_definitions(polyseed PRIVATE POLYSEED_SHARED)
-set_target_properties(polyseed PROPERTIES VERSION 2.0.0
+set_target_properties(polyseed PROPERTIES VERSION 2.1.0
                                           SOVERSION 2
                                           C_STANDARD 11
                                           C_STANDARD_REQUIRED ON)

--- a/include/polyseed.h
+++ b/include/polyseed.h
@@ -78,6 +78,8 @@ typedef enum polyseed_status {
     POLYSEED_ERR_FORMAT = 5,
     /* Memory allocation failure */
     POLYSEED_ERR_MEMORY = 6,
+    /* Phrase matches more than one language */
+    POLYSEED_ERR_MULT_LANG = 7,
 } polyseed_status;
 
 /* Opaque struct with the seed data */
@@ -274,6 +276,24 @@ size_t polyseed_encode(const polyseed_data* seed, const polyseed_lang* lang,
 POLYSEED_API
 polyseed_status polyseed_decode(const char* str, polyseed_coin coin,
     const polyseed_lang** lang_out, polyseed_data** seed_out);
+
+/**
+ * Decodes the seed from a mnemonic phrase with a specific language.
+ * This should be used if polyseed_decode returns POLYSEED_ERR_MULT_LANG.
+ *
+ * @param str is the mnemonic phrase as a C-style string. Must not be NULL.
+ * @param coin is the coin the mnemonic phrase is intended for.
+ * @param lang is a pointer to the language to decode the seed.
+ *        Must not be NULL.
+ * @param seed_out is a pointer where the seed pointer will be stored.
+ *        Must not be NULL.
+ *
+ * @return POLYSEED_OK if the operation was successful. Other values indicate
+ *         an error (in that case, *seed_out is undefined).
+ */
+POLYSEED_API
+polyseed_status polyseed_decode_explicit(const char* str, polyseed_coin coin,
+    const polyseed_lang* lang, polyseed_data** seed_out);
 
 /**
  * Serializes the seed data in a platform-independent way.

--- a/src/lang.h
+++ b/src/lang.h
@@ -26,8 +26,11 @@ typedef const char* polyseed_phrase[POLYSEED_NUM_WORDS];
 POLYSEED_PRIVATE int polyseed_lang_find_word(const polyseed_lang* lang,
     const char* word);
 
-POLYSEED_PRIVATE bool polyseed_phrase_decode(const polyseed_phrase phrase,
+POLYSEED_PRIVATE polyseed_status polyseed_phrase_decode(const polyseed_phrase phrase,
     uint_fast16_t idx_out[POLYSEED_NUM_WORDS], const polyseed_lang** lang_out);
+
+POLYSEED_PRIVATE polyseed_status polyseed_phrase_decode_explicit(const polyseed_phrase phrase,
+    const polyseed_lang* lang, uint_fast16_t idx_out[POLYSEED_NUM_WORDS]);
 
 POLYSEED_PRIVATE void polyseed_lang_check(const polyseed_lang* lang);
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -71,6 +71,10 @@ static const char* g_phrase_es5 =
     "eje fin part cele tab pest lien puma "
     "pris hora rega leng exis lapi lote sono";
 
+static const char* g_phrase_es_mult =
+    "impo sort usua cabi venu nobl oliv clim "
+    "cont barr marc auto prod vaca torn fati";
+
 static const char* g_phrase_garbage1 = "xxx xxx";
 
 static const char* g_phrase_garbage2 =
@@ -662,6 +666,25 @@ static bool test_decode_es_prefix2(void) {
     return true;
 }
 
+static bool test_decode_es_mult1(void) {
+    const polyseed_lang* lang;
+    polyseed_data* seed;
+    polyseed_status res = polyseed_decode(g_phrase_es_mult, POLYSEED_MONERO, &lang, &seed);
+    assert(res == POLYSEED_ERR_MULT_LANG);
+    return true;
+}
+
+static bool test_decode_es_mult2(void) {
+    if (g_lang_es == NULL) {
+        return false;
+    }
+    polyseed_data* seed;
+    polyseed_status res = polyseed_decode_explicit(g_phrase_es_mult, POLYSEED_MONERO, g_lang_es, &seed);
+    assert(res == POLYSEED_OK);
+    polyseed_free(seed);
+    return true;
+}
+
 static bool test_free2(void) {
     polyseed_free(g_seed2);
     return true;
@@ -863,6 +886,8 @@ int main() {
     RUN_TEST(test_decode_es_prefix1);
     RUN_TEST(test_decode_es_suffix);
     RUN_TEST(test_decode_es_prefix2);
+    RUN_TEST(test_decode_es_mult1);
+    RUN_TEST(test_decode_es_mult2);
     RUN_TEST(test_free2);
     RUN_TEST(test_inject3);
     RUN_TEST(test_features3a);


### PR DESCRIPTION
Resolves #11

Changes:

1. `polyseed_decode` now returns `POLYSEED_ERR_MULT_LANG` if the seed phrase matches more than one language.
2. Added a new public function `polyseed_decode_explicit` where the language to decode the phrase is passed as a parameter.