### PR TITLE
Add Monero-Carrot coin derivation path

### DIFF
--- a/include/polyseed.h
+++ b/include/polyseed.h
@@ -57,6 +57,7 @@ typedef enum polyseed_coin {
     POLYSEED_MONERO = 0,
     POLYSEED_AEON = 1,
     POLYSEED_WOWNERO = 2,
+    POLYSEED_MONERO_CARROT = 3,
     /* Other coins should be added here sequentially. */
     /* The maximum supported value is 2047. */
     /* When adding a new coin, please open a pull request: */


### PR DESCRIPTION
Calling code is meant to call `polyseed_decode(... POLYSEED_MONERO ... )` to preserve backwards compatibility with existing seeds, and call `polyseed_keygen(... POLYSEED_MONERO_CARROT ...)` to generate new Carrot key material, since we can't reuse the old key material for post-quantum privacy's sake. We just need to reserve this coin code so it doesn't get used for something else / is standardized. Modifying the salt, while using the same seed, in the KDF solves all of our engineering concerns as it relates to Polyseed and Carrot migrations, so it's just a question of taste.

Resolves #15
